### PR TITLE
Update 0.1.0

### DIFF
--- a/FlowHub.DataAccess/FlowHub.DataAccess.csproj
+++ b/FlowHub.DataAccess/FlowHub.DataAccess.csproj
@@ -28,7 +28,7 @@
   
 	<ItemGroup>
 	  <PackageReference Include="LiteDB.Async" Version="0.1.6" />
-	  <PackageReference Include="MongoDB.Driver" Version="2.19.2" />
+	  <PackageReference Include="MongoDB.Driver" Version="2.20.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/FlowHub.DataAccess/IRepositories/IExpendituresRepository.cs
+++ b/FlowHub.DataAccess/IRepositories/IExpendituresRepository.cs
@@ -5,6 +5,7 @@ namespace FlowHub.DataAccess.IRepositories;
 public interface IExpendituresRepository
 {
     //   Task<List<ExpendituresModel>> GetAllExpendituresAsync();
+    event Action OfflineExpendituresListChanged;
     Task<List<ExpendituresModel>> GetAllExpendituresAsync();
    // List<ExpendituresModel> OnlineExpendituresList { get; set; }
 

--- a/FlowHub.Main/AppShell.xaml
+++ b/FlowHub.Main/AppShell.xaml
@@ -7,6 +7,7 @@
         xmlns:viewsExpenditures="clr-namespace:FlowHub.Main.Views.Desktop.Expenditures"
         xmlns:viewsIncomes="clr-namespace:FlowHub.Main.Views.Desktop.Incomes"
         xmlns:viewsSettings="clr-namespace:FlowHub.Main.Views.Desktop.Settings"
+        xmlns:viewsStatistics="clr-namespace:FlowHub.Main.Views.Desktop.Statistics"
         Shell.NavBarIsVisible="False"
         Shell.FlyoutBehavior="Disabled"
         CurrentItem ="{x:Reference login}">
@@ -34,6 +35,12 @@
             <ShellContent Title="Manage Incomes"
                           ContentTemplate="{DataTemplate viewsIncomes:ManageIncomesD}"
                           Route="ManageIncomes"/>
+        </Tab>
+
+        <Tab Title="Flow Insights">
+            <ShellContent Title="Flow Insights"
+                          ContentTemplate="{DataTemplate viewsStatistics:StatisticsPageD}"
+                          Route="Statistics"/>
         </Tab>
         
         <Tab Title="Planning">

--- a/FlowHub.Main/AppShell.xaml.cs
+++ b/FlowHub.Main/AppShell.xaml.cs
@@ -2,6 +2,7 @@ using FlowHub.Main.Views.Desktop;
 using FlowHub.Main.Views.Desktop.Expenditures;
 using FlowHub.Main.Views.Desktop.Incomes;
 using FlowHub.Main.Views.Desktop.Settings;
+using FlowHub.Main.Views.Desktop.Statistics;
 
 namespace FlowHub.Main;
 
@@ -15,10 +16,12 @@ public partial class AppShell : Shell
 		Routing.RegisterRoute(nameof(LoginD), typeof(LoginD));
 
 		Routing.RegisterRoute(nameof(ManageExpendituresPageD), typeof(ManageExpendituresPageD));
-		
+
 		Routing.RegisterRoute(nameof(UpSertExpenditurePageD), typeof(UpSertExpenditurePageD));
 
 		Routing.RegisterRoute(nameof(ManageIncomesD), typeof(ManageIncomesD));
+
+		Routing.RegisterRoute(nameof(StatisticsPageD), typeof(StatisticsPageD));
 
 		Routing.RegisterRoute(nameof(UserSettingsPageD), typeof(UserSettingsPageD));
 	}

--- a/FlowHub.Main/FlowHub.Main.csproj
+++ b/FlowHub.Main/FlowHub.Main.csproj
@@ -187,6 +187,9 @@
 	  <MauiXaml Update="Views\Desktop\Settings\UserSettingsPageD.xaml">
 	    <Generator>MSBuild:Compile</Generator>
 	  </MauiXaml>
+	  <MauiXaml Update="Views\Desktop\Statistics\StatisticsPageD.xaml">
+	    <Generator>MSBuild:Compile</Generator>
+	  </MauiXaml>
 	  <MauiXaml Update="Views\Mobile\Expenditures\ManageExpendituresM.xaml">
 	    <Generator>MSBuild:Compile</Generator>
 	  </MauiXaml>

--- a/FlowHub.Main/MauiProgram.cs
+++ b/FlowHub.Main/MauiProgram.cs
@@ -12,6 +12,7 @@ using FlowHub.Main.Views.Desktop;
 using FlowHub.Main.Views.Desktop.Expenditures;
 using FlowHub.Main.Views.Desktop.Incomes;
 using FlowHub.Main.Views.Desktop.Settings;
+using FlowHub.Main.Views.Desktop.Statistics;
 using FlowHub.Main.Views.Mobile;
 using FlowHub.Main.Views.Mobile.Expenditures;
 using FlowHub.Main.Views.Mobile.Expenditures.PlannedExpenditures.MonthlyPlannedExp;
@@ -120,6 +121,8 @@ public static class MauiProgram
         builder.Services.AddSingleton<UpSertMonthlyPlannedExpPageM>();
 
         /* -- Section For Statistics --*/
+        builder.Services.AddTransient<StatisticsPageD>();
+
         builder.Services.AddTransient<StatisticsPageM>();
         builder.Services.AddSingleton<SingleMonthStatsPageM>();
 /*--------------------------------------------------------------------------------------------------------------------------------*/

--- a/FlowHub.Main/Platforms/Android/NavigationsMethods/ManageExpendituresNavs.cs
+++ b/FlowHub.Main/Platforms/Android/NavigationsMethods/ManageExpendituresNavs.cs
@@ -17,7 +17,7 @@ public static class ManageExpendituresNavs
 
     public static async Task FromManageExpToSingleMonthStats(Dictionary<string, object> navParams)
     {
-        await Shell.Current.GoToAsync(nameof(SingleMonthStatsPageM), true, navParams);
+        await Shell.Current.GoToAsync(nameof(StatisticsPageM), true, navParams);
     }
     public static async Task ReturnOnce()
     {

--- a/FlowHub.Main/Platforms/Windows/NavigationsMethods/ManageExpendituresNavs.cs
+++ b/FlowHub.Main/Platforms/Windows/NavigationsMethods/ManageExpendituresNavs.cs
@@ -1,4 +1,5 @@
 ﻿using FlowHub.Main.Views.Desktop.Expenditures;
+using FlowHub.Main.Views.Desktop.Statistics;
 
 namespace FlowHub.Main.Platforms.NavigationMethods;
 
@@ -14,7 +15,7 @@ public static class ManageExpendituresNavs
     }
     public static async Task FromManageExpToSingleMonthStats(Dictionary<string, object> navParams)
     {
-        //await Shell.Current.GoToAsync(nameof(SingleMonthStatsPageM), true, navParams);
+        await Shell.Current.GoToAsync(nameof(StatisticsPageD), true, navParams);
     }
 
     public static async Task ReturnOnce()

--- a/FlowHub.Main/PopUpPages/InputCurrencyForPrintPopUpPage.xaml.cs
+++ b/FlowHub.Main/PopUpPages/InputCurrencyForPrintPopUpPage.xaml.cs
@@ -10,7 +10,6 @@ public partial class InputCurrencyForPrintPopUpPage : Popup
         DisplayAlertText.Text = DisplayText;
         //TODO: Pass the user currency in th title of the popup page and remove this display text
 
-        
         List<string> ListOfCurrencies = new()
         {
             "AED", // United Arab Emirates Dirham

--- a/FlowHub.Main/Utilities/EnumConverter.cs
+++ b/FlowHub.Main/Utilities/EnumConverter.cs
@@ -20,7 +20,7 @@ public class EnumConverter : IValueConverter
         return null;
     }
 
-    private object GetDescription(Enum enumValue)
+    public static string GetDescription(Enum enumValue)
     {
         FieldInfo fieldInfo = enumValue.GetType().GetField(enumValue.ToString());
         var attribute = (DescriptionAttribute)fieldInfo.GetCustomAttribute(typeof(DescriptionAttribute));

--- a/FlowHub.Main/ViewModels/Expenditures/UpSertExpenditureVM.cs
+++ b/FlowHub.Main/ViewModels/Expenditures/UpSertExpenditureVM.cs
@@ -16,7 +16,7 @@ public partial class UpSertExpenditureVM : ObservableObject
 {
     private readonly IExpendituresRepository _expenditureService;
     private readonly IUsersRepository userService;
-    
+
     public UpSertExpenditureVM(IExpendituresRepository expendituresRepository, IUsersRepository usersRepository, ExpendituresModel singleExpendituresDetails, string pageTitle, bool isAdd, UsersModel activeUser)
     {
         _expenditureService = expendituresRepository;
@@ -87,7 +87,6 @@ public partial class UpSertExpenditureVM : ObservableObject
         CancellationTokenSource cancellationTokenSource = new();
         ToastDuration duration = ToastDuration.Short;
 
-        
         if (SingleExpenditureDetails.Id is not null)
         {
             UpdateExpenditureAsync(14, cancellationTokenSource, duration);
@@ -203,7 +202,6 @@ public partial class UpSertExpenditureVM : ObservableObject
             }
         }
     }
-
 
     public void AddTax(TaxModel tax)
     {

--- a/FlowHub.Main/ViewModels/HomePageVM.cs
+++ b/FlowHub.Main/ViewModels/HomePageVM.cs
@@ -8,6 +8,8 @@ using CommunityToolkit.Maui.Views;
 using FlowHub.Main.ViewModels.Expenditures;
 using FlowHub.Main.Views;
 using FlowHub.Main.Utilities;
+using System.Collections.ObjectModel;
+using CommunityToolkit.Maui.Core.Extensions;
 
 //This is the view model for the HOME PAGE
 namespace FlowHub.Main.ViewModels;
@@ -29,7 +31,9 @@ public partial class HomePageVM : ObservableObject
     }
 
     [ObservableProperty]
-    private ExpendituresModel _expendituresDetails = new() { DateSpent = DateTime.Now };
+    ObservableCollection<ExpendituresModel> _latestExpenditures;
+    [ObservableProperty]
+    ObservableCollection<IncomeModel> _latestIncomes;
 
     [ObservableProperty]
     public int totalExp;
@@ -57,7 +61,11 @@ public partial class HomePageVM : ObservableObject
         UserCurrency = ActiveUser.UserCurrency;
         var ListOfExp = await _expendituresService.GetAllExpendituresAsync();
 
-        ExpendituresDetails = ListOfExp.Count != 0 ? ListOfExp.OrderByDescending(s => s.DateSpent).First() : (new() { DateSpent = DateTime.Now });
+        LatestExpenditures = ListOfExp.Count != 0 
+            ? ListOfExp.OrderByDescending(s => s.DateSpent).Take(5).ToObservableCollection() 
+            : new ObservableCollection<ExpendituresModel>();
+
+        
     }
 
     [RelayCommand]
@@ -94,7 +102,8 @@ public partial class HomePageVM : ObservableObject
             {
                 ExpendituresModel exp = (ExpendituresModel)UpSertResult.Data;
                 //add logic if this exp is the latest in terms of datetime
-                ExpendituresDetails = exp;
+                LatestExpenditures.Add(exp);
+                LatestExpenditures = LatestExpenditures.OrderByDescending(s => s.DateSpent).Take(5).ToObservableCollection();
                 PocketMoney -= exp.AmountSpent;
             }
         }

--- a/FlowHub.Main/ViewModels/LoginVM.cs
+++ b/FlowHub.Main/ViewModels/LoginVM.cs
@@ -160,7 +160,6 @@ public partial class LoginVM : ObservableObject
         }
     }
 
-
     [RelayCommand]
     public async void GoToHomePageFromLogin()
     {

--- a/FlowHub.Main/ViewModels/Statistics/StatisticsPageVM.cs
+++ b/FlowHub.Main/ViewModels/Statistics/StatisticsPageVM.cs
@@ -1,24 +1,283 @@
-﻿using CommunityToolkit.Mvvm.ComponentModel;
+﻿using CommunityToolkit.Maui.Core.Extensions;
+using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using FlowHub.DataAccess.IRepositories;
+using FlowHub.Main.Utilities;
+using FlowHub.Main.ViewModels.Expenditures;
 using FlowHub.Models;
 using LiveChartsCore;
+using LiveChartsCore.Defaults;
 using LiveChartsCore.Kernel;
 using LiveChartsCore.SkiaSharpView;
 using LiveChartsCore.SkiaSharpView.Painting;
+using LiveChartsCore.SkiaSharpView.VisualElements;
 using SkiaSharp;
 using System.Collections.ObjectModel;
+using System.Diagnostics;
+using System.Globalization;
+using System.Linq;
 
 namespace FlowHub.Main.ViewModels.Statistics;
 
+[QueryProperty(nameof(GroupedExpenditures), "GroupedExpList")]
 public partial class StatisticsPageVM : ObservableObject
 {
 	private readonly IExpendituresRepository expendituresService;
 	public StatisticsPageVM(IExpendituresRepository expRepo)
 	{
 		expendituresService = expRepo;
+		
 	}
 
+	[ObservableProperty]
+	ObservableCollection<DateGroup> groupedExpenditures;
+
+	[ObservableProperty]
+	ObservableCollection<ExpendituresModel> expendituresForSelectedMonth;
+	[ObservableProperty]
+	ISeries[] mySeries;
+
+	[ObservableProperty]
+	IEnumerable<ISeries> myPieSeries;
+    public LabelVisual MyPieCategoriesTitle { get; set; } =
+             new LabelVisual
+             {
+                 Text = "Flows by Category",
+#if ANDROID
+				 TextSize = 60,
+#elif WINDOWS
+				 TextSize = 30,
+#endif
+				 Padding = new LiveChartsCore.Drawing.Padding(10),
+                 Paint = new SolidColorPaint(SKColors.DarkSlateBlue)
+             };
+
+    [ObservableProperty]
+	Axis[] xAxes;
+
+	[ObservableProperty]
+	string[] monthNames;
+	[ObservableProperty]
+	int[] yearNames;
+	[ObservableProperty]
+	string selectedMonthName;
+	[ObservableProperty]
+	int selectedMonthValue;
+	[ObservableProperty]
+	int selectedYearValue;
+
+	[ObservableProperty]
+	string selectedCategoryName;
+
+	string[] AllDataAvailableMonths;
+
+	[ObservableProperty]
+	string currency;
+
+	[ObservableProperty]
+	int totalNumberOfExpenditures;
+	[ObservableProperty]
+	double totalMonthlyAmount;
+	[ObservableProperty]
+	double averageDailyAmountInAMonth;
+	[ObservableProperty]
+	double biggestAmountInAMonth;
+	[ObservableProperty]
+	double smallestAmountInAMonth;
+
+	static bool loaded;
+	[RelayCommand]
+	public void PageLoaded()
+	{
+		if (!loaded)
+		{
+            SelectedMonthName = DateTime.Now.ToString("MMMM");
+            SelectedYearValue = DateTime.Now.Year;
+            MonthNames = GroupedExpenditures.Select(g => new DateTime(g.Date.Year, g.Date.Month, 1))
+                .Distinct()
+                .Order()
+                .Select(date => date.ToString("MMMM"))
+                .ToArray();
+            YearNames = GroupedExpenditures.Select(g => g.Date.Year)
+                .Distinct()
+                .OrderBy(y => y)
+                .ToArray();
+            Currency = GroupedExpenditures.First().Currency;
+
+            PopulateDataGridWithSelectedMonthData();
+            DisplayAllMonthsExpensesChart();
+			loaded = true;
+        }
+    }
+
+    ObservableCollection<ExpendituresModel> OriginalExpForSelectedMonth = new();
+    [RelayCommand]
+	public void PopulateDataGridWithSelectedMonthData()
+	{
+		if (SelectedYearValue == 0)
+		{
+			SelectedYearValue = DateTime.Now.Year;
+		}
+		SelectedMonthName ??= DateTime.Now.ToString("MMMM");
+
+		DateTime targetDate = new(SelectedYearValue, DateTime.ParseExact(SelectedMonthName, "MMMM", CultureInfo.CurrentCulture).Month, 1);
+		SelectedMonthValue = targetDate.Month;
+
+		ExpendituresForSelectedMonth = GroupedExpenditures
+			.Where(g => g.Date.Month == targetDate.Month && g.Date.Year == SelectedYearValue)
+			.SelectMany(g => g)
+			.ToObservableCollection();
+
+        OriginalExpForSelectedMonth = ExpendituresForSelectedMonth;
+        TotalNumberOfExpenditures = ExpendituresForSelectedMonth.Count;
+		TotalMonthlyAmount = ExpendituresForSelectedMonth.Sum(e => e.AmountSpent);
+		AverageDailyAmountInAMonth = TotalMonthlyAmount / DateTime.DaysInMonth(targetDate.Year, targetDate.Month);
+		BiggestAmountInAMonth = ExpendituresForSelectedMonth.Max(e => e.AmountSpent);
+		SmallestAmountInAMonth = ExpendituresForSelectedMonth.Min(e => e.AmountSpent);
+
+		DisplaySpecificMonthCategoriesPieChart();
+	}
+
+	private void DisplayAllMonthsExpensesChart()
+	{
+		var groupedData = GroupedExpenditures
+								.GroupBy(g => new DateTime(g.Date.Year, g.Date.Month, 1))
+								.Select(g => new
+								{
+									Date = g.Key,
+									MonthName = g.Key.ToString("MMMM yyyy"),
+									TotalAmount = g.Sum(x => x.TotalAmount)
+								})
+								.OrderBy(g => g.Date)
+								.ToList();
+		var values = new ObservableCollection<ObservableValue>(groupedData
+			.Select(g => new ObservableValue(g.TotalAmount)));
+
+		AllDataAvailableMonths = groupedData.Select(g => g.MonthName).ToArray();
+
+		MySeries = new ISeries[]
+		{
+			new ColumnSeries<ObservableValue>
+			{
+				Values = values,
+				TooltipLabelFormatter = (chartpoint) =>
+				$"{AllDataAvailableMonths[chartpoint.Context.Entity.EntityIndex]} : {chartpoint.PrimaryValue:n2} {Currency}",
+			}
+		};
+		XAxes = new Axis[]
+		{
+			new Axis
+			{
+				Labels = AllDataAvailableMonths,
+				LabelsRotation = 45,
+			}
+		};
+	}
+	
+	private List<PieChartData> listOfPieSeries;
+    private void DisplaySpecificMonthCategoriesPieChart()
+	{
+		try
+		{
+            listOfPieSeries = GroupedExpenditures
+			.SelectMany(g => g)
+			.Where(exp => exp.DateSpent.Month == SelectedMonthValue && exp.DateSpent.Year == SelectedYearValue)
+			.GroupBy(exp => exp.Category)
+			.Select(g => new PieChartData
+			{
+				Category = g.Key.ToString(),
+				TotalCount = g.Count()
+			})
+			.ToList();
+
+            MyPieSeries = listOfPieSeries.Select(data => new PieSeries<double>
+            {
+                Values = new double[] { data.TotalCount },
+                Name = data.Category,
+                TooltipLabelFormatter = p => $"{p.PrimaryValue} {(p.PrimaryValue == 1 ? "Flow" : "Flows")} in {data.Category}",
+                DataLabelsPosition = LiveChartsCore.Measure.PolarLabelsPosition.Outer,
+                DataLabelsFormatter = _ => $"{data.Category}",
+                IsVisibleAtLegend = true
+            }).ToArray();
+
+
+        }
+        catch (Exception ex)
+		{
+			Debug.WriteLine("ERROR HERE " + ex.Message);
+		}
+	}
+
+    int? lastIndex = null;
+	[RelayCommand]
+	public void BarChartPointHover(ChartPoint point)
+    {
+        if (point is null)
+		{
+			return;
+        }
+
+        int currentIndex = point.Context.Entity.EntityIndex;
+        if (currentIndex == lastIndex)
+		{
+			return;
+		}
+
+		lastIndex = currentIndex;
+
+		var selectedDateLabel = AllDataAvailableMonths[currentIndex];
+
+        DateTime selectedDate;
+		var s = DateTime.TryParseExact(selectedDateLabel, "MMMM yyyy", CultureInfo.InvariantCulture, DateTimeStyles.None, out selectedDate);
+
+		SelectedMonthValue = selectedDate.Month;
+		SelectedYearValue = selectedDate.Year;
+		SelectedMonthName = selectedDate.ToString("MMMM");
+		SelectedCategoryName = string.Empty;
+	 	UpdateExpForSelectedMonthCollection();
+    }
+
+	private async void UpdateExpForSelectedMonthCollection()
+	{
+		await Task.Delay(50);
+		ExpendituresForSelectedMonth = GroupedExpenditures
+			.Where(g => g.Date.Month == SelectedMonthValue && g.Date.Year == SelectedYearValue)
+			.SelectMany(g => g)
+			.ToObservableCollection();
+	}
+
+
+	string? lastPieCategory = null;
+	[RelayCommand]
+	public async void PieChartClick(ChartPoint point)
+    {
+        await Task.Delay(50);
+        if (point is null)
+        {
+            return;
+        }
+        
+		string currentCategory = point.AsDataLabel;
+
+		if (currentCategory == lastPieCategory)
+		{
+			ExpendituresForSelectedMonth = OriginalExpForSelectedMonth;
+			return;
+		}
+
+		lastPieCategory = currentCategory;
+
+		SelectedCategoryName = currentCategory;
+
+		UpdateExpForSelectedMonthToShowOnlyCategories();
+    }
+
+    private async void UpdateExpForSelectedMonthToShowOnlyCategories()
+    {
+        await Task.Delay(50);
+        ExpendituresForSelectedMonth = OriginalExpForSelectedMonth.Where(e => e.Category.ToString() == SelectedCategoryName)
+            .ToObservableCollection();
+    }
     public List<ExpendituresModel> listOfExp { get; set; }
     public ExpendituresModel[] listOfExpDec { get; set; }
 
@@ -39,111 +298,110 @@ public partial class StatisticsPageVM : ObservableObject
 	public ObservableCollection<ISeries> LineSeries { get; set; }
 
 	[RelayCommand]
-	public void PageLoaded()
-	{
-		Series2 = new ()
-		{
-			new ColumnSeries<double>
-			{
-				IsHoverable = false, // disables the series from the tooltips 
-				Values = new double[] { 44, 20, 49, 10, 12, 38, 7 },
-				Stroke = null,
-				Fill = new SolidColorPaint(new SKColor(30, 30, 30, 30)),
+	//public void PageLoaded()
+	//{
+	//	Series2 = new ()
+	//	{
+	//		new ColumnSeries<double>
+	//		{
+	//			IsHoverable = false, // disables the series from the tooltips 
+	//			Values = new double[] { 44, 20, 49, 10, 12, 38, 7 },
+	//			Stroke = null,
+	//			Fill = new SolidColorPaint(new SKColor(30, 30, 30, 30)),
 
-				IgnoresBarPosition = false
-			}
-		};
+	//			IgnoresBarPosition = false
+	//		}
+	//	};
 
-		listOfExp = new();
+	//	listOfExp = new();
 
-		listOfExp = expendituresService.OfflineExpendituresList;
+	//	listOfExp = expendituresService.OfflineExpendituresList;
 
-		//Don't forget to add year == current year in condition
-		listOfExpDec = new ExpendituresModel[listOfExp.Count];
-		listOfExpDec = listOfExp.Where(x => x.DateSpent.Month == 12).ToArray();
+	//	//Don't forget to add year == current year in condition
+	//	listOfExpDec = new ExpendituresModel[listOfExp.Count];
+	//	listOfExpDec = listOfExp.Where(x => x.DateSpent.Month == 12).ToArray();
 
-		/*
-		TestClass first = new("first", 1) ;
+	//	/*
+	//	TestClass first = new("first", 1) ;
 
-		TestClass sec = new("Second", 5);
-		TestClass th = new("Third", 17);
-		TestClass frth = new("Fourth", 9);
-		TestClass ffth = new("Fifth", 13);
-		List<TestClass> testClasses = new()
-		{
-			first,
-			sec,
-			th,
-			frth,
-			ffth
-		};
-		var listOfLineSeries =new List<LineSeries<double>>();
-        */
-		var listOfPieSeries = new List<PieSeries<double>>();
+	//	TestClass sec = new("Second", 5);
+	//	TestClass th = new("Third", 17);
+	//	TestClass frth = new("Fourth", 9);
+	//	TestClass ffth = new("Fifth", 13);
+	//	List<TestClass> testClasses = new()
+	//	{
+	//		first,
+	//		sec,
+	//		th,
+	//		frth,
+	//		ffth
+	//	};
+	//	var listOfLineSeries =new List<LineSeries<double>>();
+ //       */
+	//	var listOfPieSeries = new List<PieSeries<double>>();
 
-		foreach (var item in listOfExpDec)
-		{
-			listOfPieSeries.Add(new PieSeries<double>{
-				Name = item.Reason,
-				Values = new double[] { item.AmountSpent },
-				TooltipLabelFormatter =
-					(ChartPoint) => $"{ChartPoint.Context.Series.Name }: {ChartPoint.PrimaryValue:n3} {item.Currency}",
-			});
-		}
+	//	foreach (var item in listOfExpDec)
+	//	{
+	//		listOfPieSeries.Add(new PieSeries<double>{
+	//			Name = item.Reason,
+	//			Values = new double[] { item.AmountSpent },
+	//			TooltipLabelFormatter =
+	//				(ChartPoint) => $"{ChartPoint.Context.Series.Name }: {ChartPoint.PrimaryValue:n3} {item.Currency}",
+	//		});
+	//	}
 
-		Series = new List<ISeries>();
-		LineSeries = new ObservableCollection<ISeries>();
+	//	Series = new List<ISeries>();
+	//	LineSeries = new ObservableCollection<ISeries>();
 
-		Series.AddRange(listOfPieSeries);
+	//	Series.AddRange(listOfPieSeries);
 
-        LineSeries<ExpendituresModel> LinesSeriesToPlot = new()
-		{
-			Name = $"Graph of {listOfExpDec.Length} Flow Outs For December 2022",
-			TooltipLabelFormatter = (point) => $"{point.Model.Reason} : {point.Model.AmountSpent:n3} {point.Model.Currency}\n" +
-			$"{point.Model.DateSpent:dd-MMM-yy}",
-			Values = listOfExpDec,
-			Mapping =(testt, point) =>
-			{
-				point.PrimaryValue = (double)testt.AmountSpent;
-				point.SecondaryValue = point.Context.Entity.EntityIndex;
-			},
-			Stroke = new SolidColorPaint(SKColors.DarkSlateBlue) { StrokeThickness = 4 },
+ //       LineSeries<ExpendituresModel> LinesSeriesToPlot = new()
+	//	{
+	//		Name = $"Graph of {listOfExpDec.Length} Flow Outs For December 2022",
+	//		TooltipLabelFormatter = (point) => $"{point.Model.Reason} : {point.Model.AmountSpent:n3} {point.Model.Currency}\n" +
+	//		$"{point.Model.DateSpent:dd-MMM-yy}",
+	//		Values = listOfExpDec,
+	//		Mapping =(testt, point) =>
+	//		{
+	//			point.PrimaryValue = (double)testt.AmountSpent;
+	//			point.SecondaryValue = point.Context.Entity.EntityIndex;
+	//		},
+	//		Stroke = new SolidColorPaint(SKColors.DarkSlateBlue) { StrokeThickness = 4 },
 
-		//	Name = "Plot",
-		//	DataLabelsSize = 30,
+	//	//	Name = "Plot",
+	//	//	DataLabelsSize = 30,
 
-		//	DataLabelsPaint = new SolidColorPaint(SKColors.White),
-		//	DataLabelsPosition = LiveChartsCore.Measure.DataLabelsPosition.Top,
-		//	Fill = null,
-		//	DataLabelsFormatter = (Series) => Series.SecondaryValue.ToString(),
-		//	Values = dataValues,
-  //          GeometrySize = 0,
-  //          LineSmoothness = 0
-        };
+	//	//	DataLabelsPaint = new SolidColorPaint(SKColors.White),
+	//	//	DataLabelsPosition = LiveChartsCore.Measure.DataLabelsPosition.Top,
+	//	//	Fill = null,
+	//	//	DataLabelsFormatter = (Series) => Series.SecondaryValue.ToString(),
+	//	//	Values = dataValues,
+ // //          GeometrySize = 0,
+ // //          LineSmoothness = 0
+ //       };
 
-        LineSeries.Add(LinesSeriesToPlot);
-		//LineSeries = new List<ISeries>()
-		//{
-		//	new LineSeries<double>
-		//	{				
-		//		DataLabelsFormatter = (point) => point.PrimaryValue.ToString(),
-		//		Values = new double[] { 5, 0, 5, 0, 5, 0 },
-		//		Fill = null,
-		//          },
+ //       LineSeries.Add(LinesSeriesToPlot);
+	//	//LineSeries = new List<ISeries>()
+	//	//{
+	//	//	new LineSeries<double>
+	//	//	{				
+	//	//		DataLabelsFormatter = (point) => point.PrimaryValue.ToString(),
+	//	//		Values = new double[] { 5, 0, 5, 0, 5, 0 },
+	//	//		Fill = null,
+	//	//          },
 
-		//          new LineSeries<double>
-		//	{
-		//		Values = new double[] { 7, 2, 7, 2, 7, 2 },
-		//		Fill = null,
-		//		GeometrySize = 0,
-		//		LineSmoothness = 1
-		//	}
+	//	//          new LineSeries<double>
+	//	//	{
+	//	//		Values = new double[] { 7, 2, 7, 2, 7, 2 },
+	//	//		Fill = null,
+	//	//		GeometrySize = 0,
+	//	//		LineSmoothness = 1
+	//	//	}
 
-		//};
+	//	//};
 
-	}
+	//}
 
-	[RelayCommand]
 	void GetNov ()
 	{
         var listOfExp = expendituresService.OfflineExpendituresList;
@@ -200,5 +458,11 @@ public partial class StatisticsPageVM : ObservableObject
 			Name = name;
 			val=Val;
 		}
+	}
+
+	public class PieChartData
+	{
+		public double TotalCount{ get; set; }
+		public string Category { get; set; }
 	}
 }

--- a/FlowHub.Main/Views/Desktop/Expenditures/ManageExpendituresPageD.xaml
+++ b/FlowHub.Main/Views/Desktop/Expenditures/ManageExpendituresPageD.xaml
@@ -81,13 +81,20 @@
                          HeightRequest="55"
                              x:Name="SyncButton"
                              Command="{Binding SyncExpTestCommand}"/>
+
+            <ImageButton x:Name="pie_chart" Source="{AppThemeBinding Dark=pie_chart.png, Light=pie_chart_l.png}" 
+                         HeightRequest="55"
+                         IsVisible="{Binding ShowStatisticBtn}"
+                         Command="{Binding GoToSpecificStatsPageCommand}"/>
         </VerticalStackLayout>
 
         <dg:DataGrid ItemsSource="{Binding ExpendituresList}"  BackgroundColor="#201F24" 
                      WidthRequest="1000"
                      HeaderBackground="DarkSlateBlue"
                      RowHeight="50"
+                     HeaderHeight="40"
                      BorderColor="Transparent"
+                     
                      HorizontalOptions="CenterAndExpand" x:Name="ExpDG" >
             <dg:DataGrid.NoDataView>
                 <VerticalStackLayout Margin="40,20" MinimumWidthRequest="400">
@@ -125,7 +132,7 @@
                         </DataTemplate>
                     </dg:DataGridColumn.CellTemplate>
                 </dg:DataGridColumn>
-                <dg:DataGridColumn Title="Amount Spent">
+                <dg:DataGridColumn Title="Amount Spent" SortingEnabled="False">
                     <dg:DataGridColumn.CellTemplate>
                         <DataTemplate x:DataType="models:ExpendituresModel">
                             <Label TextColor="White" BackgroundColor="#201F24" 

--- a/FlowHub.Main/Views/Desktop/Expenditures/ManageExpendituresPageD.xaml.cs
+++ b/FlowHub.Main/Views/Desktop/Expenditures/ManageExpendituresPageD.xaml.cs
@@ -14,14 +14,15 @@ public partial class ManageExpendituresPageD : ContentPage
 		InitializeComponent();
 		viewModel = vm;
 		this.BindingContext = vm;
-
-	}
+        rotation = new Animation(v => SyncButton.Rotation = v,
+            0, 360, Easing.Linear);
+    }
 
     protected override void OnAppearing()
     {
         base.OnAppearing();
 		viewModel.PageloadedAsyncCommand.Execute(null);
-        
+
         //ExpDG.SortedColumnIndex = 0;
     }
 
@@ -41,9 +42,6 @@ public partial class ManageExpendituresPageD : ContentPage
             }
         }
     }
-
-
-
 
     private async void ExportToPDFImageButton_Clicked(object sender, EventArgs e)
     {

--- a/FlowHub.Main/Views/Desktop/HomePageD.xaml
+++ b/FlowHub.Main/Views/Desktop/HomePageD.xaml
@@ -48,61 +48,56 @@
                     Grid.Row="0"
                 Margin="1"
                 Padding="5"
-                WidthRequest="430"
-                
+                WidthRequest="450"                
                 Stroke="DarkSlateBlue"
                 StrokeThickness="2"
                 StrokeShape="RoundRectangle 8">
-                <VerticalStackLayout Spacing="10" Margin="6">
-                    <Label Text="Latest Flow Out"
-                            FontSize="25"
-                            HorizontalOptions="Center"
-                           Margin="90,0,0,0"
-                            WidthRequest="300"/>
+                <VerticalStackLayout Spacing="5">
+                    <Label Text="Latest Flow Outs" FontSize="25" HorizontalOptions="Center" Padding="10,0,0,0"/>
                     <BoxView
                         Color="DarkSlateBlue"
-                        HeightRequest="2"
+                        HeightRequest="3"
                         HorizontalOptions="Fill"/>
-                    <HorizontalStackLayout>
-                        <Label Text="Reason: "
-                           FontSize="18"
-                            HorizontalOptions="Start"
-                            />
-                        <Label Text="{Binding ExpendituresDetails.Reason} "
-                           FontSize="18"
-                            HorizontalOptions="Start"
-                           Margin="10,0,0,0"
-                            />
-                    </HorizontalStackLayout>
-                    <HorizontalStackLayout>
-                        <Label Text="Amount Spent :"
-                           FontSize="18"
-                            HorizontalOptions="Start"
-                            />
-                        <Label Text="{Binding ExpendituresDetails.AmountSpent, StringFormat='{0:n2}'} "
-                           FontSize="18"
-                            HorizontalOptions="Start"
-                           Margin="5,0,0,0"
-                            />
-                        <Label Text="{Binding UserCurrency}"
-                           FontSize="18"
-                            HorizontalOptions="Start"
-                           Margin="5,0,0,0"
-                            />
-                    </HorizontalStackLayout>
-                    <HorizontalStackLayout Margin="0,0,0,15">
-                        <Label Text="Date Spent:"
-                           FontSize="18"
-                            HorizontalOptions="Start"
-                            />
-                        <Label Text="{Binding ExpendituresDetails.DateSpent, StringFormat='{0:dd MMMM, yyyy}'}"
-                           FontSize="18"
-                            HorizontalOptions="Start"
-                           Margin="10,0,0,0"
-                            />
-                    </HorizontalStackLayout>
+                    
+                    <CollectionView ItemsSource="{Binding LatestExpenditures}" HorizontalOptions="FillAndExpand">
+                        <CollectionView.EmptyView>
+                            <Label Text="No Flow Outs Available..." HorizontalOptions="Center" VerticalOptions="Center" />
+                        </CollectionView.EmptyView>
+                        <CollectionView.ItemTemplate>
+                            <DataTemplate x:DataType="models:ExpendituresModel">
+                                <VerticalStackLayout>
+                                    <Grid Margin="10,5">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="*" />
+                                            <ColumnDefinition Width="Auto" />
+                                        </Grid.ColumnDefinitions>
 
+                                        <StackLayout Grid.Column="0">
+                                            <Label Text="{Binding Reason}" FontAttributes="Bold"/>
+                                            <Label Text="{Binding Category}" FontSize="11" FontAttributes="Italic"/>
+                                        </StackLayout>
+
+                                        <StackLayout Grid.Column="1" HorizontalOptions="End">
+                                            <Label FontAttributes="Bold">
+                                                <Label.Text>
+                                                    <MultiBinding StringFormat="{}{0:n2} {1}">
+                                                        <Binding Path="AmountSpent"/>
+                                                        <Binding Path="Currency"/>
+                                                    </MultiBinding>
+                                                </Label.Text>
+                                            </Label>
+                                            <Label Text="{Binding DateSpent, StringFormat='{0:ddd, MMM dd}'}" FontSize="11" HorizontalTextAlignment="End" FontAttributes="Italic"/>
+                                        </StackLayout>
+                                    </Grid>
+                                    <BoxView  Color="DarkSlateBlue" HeightRequest="0.5" HorizontalOptions="Fill"/>
+                                </VerticalStackLayout>
+                               
+
+                            </DataTemplate>
+                        </CollectionView.ItemTemplate>
+                    </CollectionView>
                 </VerticalStackLayout>
+
 
             </Border>
             <!-- End Section for Expenditure display-->
@@ -114,33 +109,23 @@
                 Margin="1"
                 Padding="5"
                 Stroke="DarkSlateBlue"
+                WidthRequest="450"
                 StrokeThickness="2"
                 StrokeShape="RoundRectangle 8">
-                <VerticalStackLayout Spacing="10" Margin="6">
-                    <Label Text="Latest Flow In"
-                            FontSize="25"
-                            HorizontalOptions="Center"
-                           Margin="90,0,0,0"
-                           Padding="10,0,0,0"
-                            WidthRequest="300"/>
+                <VerticalStackLayout Spacing="5">
+                    <Label Text="Latest Flow Ins" FontSize="25" HorizontalOptions="Center" Padding="10,0,0,0"/>
                     <BoxView
                         Color="DarkSlateBlue"
-                        HeightRequest="2"
+                        HeightRequest="3"
                         HorizontalOptions="Fill"/>
-                    <Label Text="Reason: "
-                           FontSize="18"
-                            HorizontalOptions="Start"
-                            WidthRequest="300"/>
-
-
-                    <Label Text="Amount Received:"
-                           FontSize="18"
-                            HorizontalOptions="StartAndExpand"
-                            WidthRequest="300"/>
-                    <Label Text="Date Received:"
-                           FontSize="18"
-                            HorizontalOptions="StartAndExpand"
-                            WidthRequest="300"/>
+                    <CollectionView ItemsSource="{Binding LatestIncomes}">
+                        <CollectionView.EmptyView>
+                            <VerticalStackLayout VerticalOptions="Center">
+                                <Image Source="nothing_found.png" MaximumHeightRequest="50"/>
+                                <Label Text="No Flow Outs Available..." HorizontalOptions="Center" VerticalOptions="Center" />
+                            </VerticalStackLayout>
+                        </CollectionView.EmptyView>
+                    </CollectionView>
 
                 </VerticalStackLayout>
 

--- a/FlowHub.Main/Views/Desktop/Statistics/StatisticsPageD.xaml
+++ b/FlowHub.Main/Views/Desktop/Statistics/StatisticsPageD.xaml
@@ -1,0 +1,189 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="FlowHub.Main.Views.Desktop.Statistics.StatisticsPageD"
+             xmlns:viewModel="clr-namespace:FlowHub.Main.ViewModels.Statistics"
+             xmlns:material="clr-namespace:UraniumUI.Material.Controls;assembly=UraniumUI.Material"             
+             xmlns:models="clr-namespace:FlowHub.Models;assembly=FlowHub.Models"
+             xmlns:toolkit="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
+             xmlns:lvc="clr-namespace:LiveChartsCore.SkiaSharpView.Maui;assembly=LiveChartsCore.SkiaSharpView.Maui"
+             xmlns:dg="clr-namespace:Maui.DataGrid;assembly=Maui.DataGrid"
+             x:DataType="viewModel:StatisticsPageVM"
+             x:Name="page"
+             Title="Statistics Page">
+    <toolkit:DockLayout>
+        <Label toolkit:DockLayout.DockPosition="Top"
+            FontSize="21"
+            Text="Graphs and Charts!"
+            VerticalOptions="Center" 
+            HorizontalOptions="Center" />
+        <HorizontalStackLayout HorizontalOptions="Center" Spacing="15">
+            <material:PickerField ItemsSource="{Binding MonthNames}" SelectedItem="{Binding SelectedMonthName}" BorderColor="DarkSlateGray"
+                                  SelectedValueChangedCommand="{Binding PopulateDataGridWithSelectedMonthDataCommand}"
+                                  Title="Month"/>
+            <material:PickerField ItemsSource="{Binding YearNames}" SelectedItem="{Binding SelectedYearValue}" BorderColor="DarkSlateGray" x:Name="YearPicker"
+                                  SelectedValueChangedCommand="{Binding PopulateDataGridWithSelectedMonthDataCommand}"
+                                  Title="Year"/>
+        </HorizontalStackLayout>
+        <Label Text="test total" IsVisible="False" toolkit:DockLayout.DockPosition="Bottom" HorizontalOptions="Center"/>
+
+        <HorizontalStackLayout Spacing="15" toolkit:DockLayout.DockPosition="Top" HorizontalOptions="CenterAndExpand">
+            <HorizontalStackLayout.Resources>
+                <ResourceDictionary>
+                    <Style TargetType="Border">
+                        <Setter Property="WidthRequest" Value="210"/>
+                        <Setter Property="HeightRequest" Value="65"/>
+                        <Setter Property="Padding" Value="0,3"/>
+                        <Setter Property="Margin" Value="0,10"/>
+                        <Setter Property="Stroke" Value="DarkSlateGray"/>
+                    </Style>
+                    <Style TargetType="VerticalStackLayout">
+                        <Setter Property="HorizontalOptions" Value="CenterAndExpand"/>                        
+                    </Style>
+                </ResourceDictionary>
+            </HorizontalStackLayout.Resources>
+            <Border WidthRequest="240">
+                <VerticalStackLayout>
+                    <Label Text="Total Number of Flows" FontSize="20" />
+                    <Label Text="{Binding TotalNumberOfExpenditures, StringFormat='{0} Flows'}" HorizontalTextAlignment="Center"/>
+                </VerticalStackLayout>             
+            </Border>
+            <Border>
+                <VerticalStackLayout>
+                    <Label Text="Total Flows Amount" FontSize="20"/>
+                    <Label HorizontalTextAlignment="Center">
+                        <Label.Text>
+                            <MultiBinding StringFormat="{}{0:n2} {1}">
+                                <Binding Path="TotalMonthlyAmount"/>
+                                <Binding Path="Currency"/>
+                            </MultiBinding>
+                        </Label.Text>
+                    </Label>
+                </VerticalStackLayout>             
+            </Border>
+            <Border>
+                <VerticalStackLayout>
+                    <Label Text="Average Daily Flow" FontSize="20"/>
+                    <Label HorizontalTextAlignment="Center">
+                        <Label.Text>
+                            <MultiBinding StringFormat="{}{0:n2} {1}">
+                                <Binding Path="AverageDailyAmountInAMonth"/>
+                                <Binding Path="Currency"/>
+                            </MultiBinding>
+                        </Label.Text>
+                    </Label>
+                </VerticalStackLayout>
+            </Border>
+            <Border>
+                <VerticalStackLayout>
+                    <Label Text="Highest Flow Cost" FontSize="20"/>
+                    <Label HorizontalTextAlignment="Center">
+                        <Label.Text>
+                            <MultiBinding StringFormat="{}{0:n2} {1}">
+                                <Binding Path="BiggestAmountInAMonth"/>
+                                <Binding Path="Currency"/>
+                            </MultiBinding>
+                        </Label.Text>
+                    </Label>
+                </VerticalStackLayout>
+            </Border>
+            <Border>
+                <VerticalStackLayout>
+                    <Label Text="Lowest Flow Cost" FontSize="20"/>
+                    <Label HorizontalTextAlignment="Center">
+                        <Label.Text>
+                            <MultiBinding StringFormat="{}{0:n2} {1}">
+                                <Binding Path="SmallestAmountInAMonth"/>
+                                <Binding Path="Currency"/>
+                            </MultiBinding>
+                        </Label.Text>
+                    </Label>
+                </VerticalStackLayout>
+            </Border>
+        </HorizontalStackLayout>
+
+        <HorizontalStackLayout toolkit:DockLayout.DockPosition="Top" HorizontalOptions="Center" Spacing="10" Margin="10">
+            <Border StrokeThickness="0">
+
+                <lvc:CartesianChart HeightRequest="350" WidthRequest="750"
+                    Series="{Binding MySeries}"
+                    XAxes="{Binding XAxes}"
+                    x:Name="DateTimeExpGraph"
+                />
+            </Border>
+            <Border StrokeThickness="0">
+                <lvc:PieChart HeightRequest="350" WidthRequest="400" x:Name="myPieChart"
+                              Title="{Binding MyPieCategoriesTitle}"
+                              Series="{Binding MyPieSeries}"
+                              LegendPosition="Right"/>
+            </Border>
+            
+        </HorizontalStackLayout>
+
+        <dg:DataGrid ItemsSource="{Binding ExpendituresForSelectedMonth}" BackgroundColor="#201F24"
+                         HorizontalOptions="Center"
+                         MinimumHeightRequest="360"                         
+                         WidthRequest="1200"
+                         RowHeight="50"
+                         HeaderHeight="40"
+                         BorderColor="Transparent"
+                         HeaderBackground="DarkSlateGray"
+                         VerticalOptions="Fill">
+            <dg:DataGrid.NoDataView>
+                <VerticalStackLayout Margin="40,20" MinimumWidthRequest="400">
+                    <Image WidthRequest="70"
+                                        HeightRequest="60"
+                                        HorizontalOptions="Center"
+                                        VerticalOptions="Center"
+                                        Source="search_property.png"/>
+                    <Label Text="No Flow Out Available..." FontSize="21" HorizontalOptions="Center" Margin="30"/>
+                </VerticalStackLayout>
+            </dg:DataGrid.NoDataView>
+            <!--Equivalent of emptyview-->
+            <dg:DataGrid.Columns>
+                <dg:DataGridColumn Title="Date Spent" PropertyName="DateSpent" SortingEnabled="True">
+                    <dg:DataGridColumn.CellTemplate>
+                        <DataTemplate x:DataType="models:ExpendituresModel">
+                            <Label Text="{Binding ., StringFormat='{0:ddd, MMMM dd, yyyy}'}" TextColor="White" 
+                                   HorizontalTextAlignment="Center"
+                                   VerticalTextAlignment="Center" BackgroundColor="#201F24"/>
+                        </DataTemplate>
+                    </dg:DataGridColumn.CellTemplate>
+                </dg:DataGridColumn>
+                <dg:DataGridColumn Title="Description" PropertyName="Reason" Width="300">
+                    <dg:DataGridColumn.CellTemplate>
+                        <DataTemplate x:DataType="models:ExpendituresModel">
+                            <Label Text="{Binding .}" TextColor="White" BackgroundColor="#201F24" 
+                                    VerticalTextAlignment="Center" HorizontalTextAlignment="Center" HorizontalOptions="FillAndExpand"/>
+                        </DataTemplate>
+                    </dg:DataGridColumn.CellTemplate>
+                </dg:DataGridColumn>
+                <dg:DataGridColumn Title="Category" PropertyName="Category">
+                    <dg:DataGridColumn.CellTemplate>
+                        <DataTemplate x:DataType="models:ExpendituresModel">
+                            <Label Text="{Binding .}" TextColor="White" BackgroundColor="#201F24" 
+                                    VerticalTextAlignment="Center" HorizontalTextAlignment="Center" HorizontalOptions="FillAndExpand"/>
+                        </DataTemplate>
+                    </dg:DataGridColumn.CellTemplate>
+                </dg:DataGridColumn>
+                <dg:DataGridColumn Title="Amount Spent" SortingEnabled="False">
+                    <dg:DataGridColumn.CellTemplate>
+                        <DataTemplate x:DataType="models:ExpendituresModel">
+                            <Label TextColor="White" BackgroundColor="#201F24" 
+                                    VerticalTextAlignment="Center" HorizontalTextAlignment="Center" HorizontalOptions="FillAndExpand">
+                                <Label.Text>
+                                    <MultiBinding StringFormat="{} {0:n2} {1}">
+                                        <Binding Path="AmountSpent"/>
+                                        <Binding Path="Currency"/>
+                                    </MultiBinding>
+                                </Label.Text>
+                            </Label>
+                        </DataTemplate>
+                    </dg:DataGridColumn.CellTemplate>
+                </dg:DataGridColumn>
+            </dg:DataGrid.Columns>
+        </dg:DataGrid>
+
+
+    </toolkit:DockLayout>
+</ContentPage>

--- a/FlowHub.Main/Views/Desktop/Statistics/StatisticsPageD.xaml.cs
+++ b/FlowHub.Main/Views/Desktop/Statistics/StatisticsPageD.xaml.cs
@@ -1,17 +1,15 @@
 using FlowHub.Main.ViewModels.Statistics;
-using LiveChartsCore.Kernel.Sketches;
-using LiveChartsCore.Kernel;
-using System.Diagnostics;
 using LiveChartsCore.SkiaSharpView.Painting;
 using SkiaSharp;
+using System.Diagnostics;
+using LiveChartsCore;
 
+namespace FlowHub.Main.Views.Desktop.Statistics;
 
-namespace FlowHub.Main.Views.Mobile.Statistics;
-
-public partial class StatisticsPageM
+public partial class StatisticsPageD : ContentPage
 {
-	private readonly StatisticsPageVM viewModel;
-	public StatisticsPageM(StatisticsPageVM vm)
+    readonly StatisticsPageVM viewModel;
+    public StatisticsPageD(StatisticsPageVM vm)
 	{
 		InitializeComponent();
 		viewModel = vm;
@@ -28,14 +26,13 @@ public partial class StatisticsPageM
 
         myPieChart.LegendTextPaint = new SolidColorPaint(SKColors.White);
     }
-    protected override bool OnBackButtonPressed()
+    int count;
+
+    private void DateTimeExpGraph_ChartPointPointerDown(LiveChartsCore.Kernel.Sketches.IChartView chart, LiveChartsCore.Kernel.ChartPoint point)
     {
-        Debug.WriteLine("Back button pressed");
-        return base.OnBackButtonPressed();
-        
-    }
-    private void BarChart_ChartPointPointerDown(IChartView chart, ChartPoint point)
-    {
-        
+        //if (point is not null)
+        //{
+        //    Debug.WriteLine(new DateTime((long) point.SecondaryValue));
+        //}
     }
 }

--- a/FlowHub.Main/Views/Mobile/Expenditures/ManageExpendituresM.xaml
+++ b/FlowHub.Main/Views/Mobile/Expenditures/ManageExpendituresM.xaml
@@ -12,9 +12,9 @@
              x:DataType="viewModels:ManageExpendituresVM"             
              x:Name="Page"
              >
-    <ContentPage.ToolbarItems>
-        <ToolbarItem IconImageSource="filter_d" Command="{Binding ShowFilterPopUpPageCommand}"/>
-    </ContentPage.ToolbarItems>
+    <!--<ContentPage.ToolbarItems>
+        <ToolbarItem IconImageSource="filter_d" Command="{Binding ShowFilterPopUpPageCommand}" />
+    </ContentPage.ToolbarItems>-->
 
     <toolkit:DockLayout Margin="5,0">
         <Label toolkit:DockLayout.DockPosition="Top" FontSize="20" FontAttributes="Bold" HorizontalOptions="Center" Margin="0,5">            
@@ -141,9 +141,9 @@
                 <ColumnDefinition Width="*"/>
             </Grid.ColumnDefinitions>
 
-            <!--<ImageButton x:Name="pie_chart" Source="{AppThemeBinding Dark=pie_chart, Light=pie_chart_l}" 
+            <ImageButton x:Name="pie_chart" Source="{AppThemeBinding Dark=pie_chart, Light=pie_chart_l}" 
                          HorizontalOptions="Start" IsVisible="{Binding ShowStatisticBtn}"
-                         Grid.Column="0" VerticalOptions="Start" Command="{Binding GoToSpecificStatsPageCommand}"/>-->
+                         Grid.Column="0" VerticalOptions="Start" Command="{Binding GoToSpecificStatsPageCommand}"/>
             <!--IsVisible="{Binding ShowStatisticBtn}"-->
             <Label FontSize="17" Margin="3" Grid.Column="0" Grid.ColumnSpan="3" HorizontalOptions="Center" VerticalOptions="End">
                 <Label.Text>
@@ -163,7 +163,7 @@
                          VerticalOptions="Start" HorizontalOptions="Center" Margin="0,0,10,0" Grid.Column="2"/>
         </Grid>
         
-        <CollectionView x:Name="ColView" IsVisible="true" ItemsSource="{Binding GroupedExpenditures}"
+        <CollectionView x:Name="ColView" IsVisible="true" ItemsSource="{Binding GroupedExpenditures}" 
                         IsGrouped="True"
                         HorizontalOptions="Center">
             <CollectionView.EmptyView>
@@ -197,9 +197,9 @@
             </CollectionView.GroupFooterTemplate>
             <CollectionView.ItemTemplate>
                 <DataTemplate x:DataType="models:ExpendituresModel">
-                    <ScrollView Margin="0,2">
+                    
                             <!--set to fill and expand for it to take the whole width of the screen-->
-                            <SwipeView HorizontalOptions="FillAndExpand" >
+                            <SwipeView HorizontalOptions="FillAndExpand" Margin="0,2">
                                 <SwipeView.LeftItems>
                                     <SwipeItem 
                                         Command="{Binding Source={x:Reference Page}, 
@@ -240,7 +240,7 @@
                                     <Rectangle Fill="#404040" HeightRequest="0.8"/>
                                 </VerticalStackLayout>
                             </SwipeView>
-                    </ScrollView>
+                    
                 </DataTemplate>
             </CollectionView.ItemTemplate>
         </CollectionView>

--- a/FlowHub.Main/Views/Mobile/Expenditures/ManageExpendituresM.xaml.cs
+++ b/FlowHub.Main/Views/Mobile/Expenditures/ManageExpendituresM.xaml.cs
@@ -54,6 +54,7 @@ public partial class ManageExpendituresM : ContentPage
         }
     }
 
+    
     protected override void OnAppearing()
     {
         base.OnAppearing();
@@ -79,14 +80,14 @@ public partial class ManageExpendituresM : ContentPage
 
     private async void FilterOption_Clicked(object sender, EventArgs e)
     {
-        var FadeOut = filterOptionsContainer.FadeTo(0, 350, easing: Easing.Linear);
-        var MoveUp = filterOptionsContainer.TranslateTo(0, -30,350, Easing.Linear);
-        var MoveColViewUp = ColView.TranslateTo(0, -30,350, Easing.Linear);
-        _ = await Task.WhenAll(FadeOut, MoveUp, MoveColViewUp);
-        filterExpander.IsExpanded = false;
-        filterOptionsContainer.TranslationY= 0;
-        ColView.TranslationY= 0;
-        await filterOptionsContainer.FadeTo(1, 0);
+        //var FadeOut = filterOptionsContainer.FadeTo(0, 350, easing: Easing.Linear);
+        //var MoveUp = filterOptionsContainer.TranslateTo(0, -30,350, Easing.Linear);
+        //var MoveColViewUp = ColView.TranslateTo(0, -30,350, Easing.Linear);
+        //_ = await Task.WhenAll(FadeOut, MoveUp, MoveColViewUp);
+        //filterExpander.IsExpanded = false;
+        //filterOptionsContainer.TranslationY= 0;
+        //ColView.TranslationY= 0;
+        //await filterOptionsContainer.FadeTo(1, 0);
     }
 
     /*

--- a/FlowHub.Main/Views/Mobile/Expenditures/UpSertExpenditurePageM.xaml.cs
+++ b/FlowHub.Main/Views/Mobile/Expenditures/UpSertExpenditurePageM.xaml.cs
@@ -7,8 +7,7 @@ namespace FlowHub.Main.Views.Mobile.Expenditures;
 public partial class UpSertExpenditurePageM : ContentPage
 {
     private readonly UpSertExpenditureVM viewModel;
-    double CurrentBalance;
-    double InitialExpAmountSpent;
+
     public UpSertExpenditurePageM(UpSertExpenditureVM vm)
     {
         InitializeComponent();

--- a/FlowHub.Main/Views/Mobile/HomePageM.xaml
+++ b/FlowHub.Main/Views/Mobile/HomePageM.xaml
@@ -3,6 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="FlowHub.Main.Views.Mobile.HomePageM"
              xmlns:viewModels="clr-namespace:FlowHub.Main.ViewModels"
+             xmlns:models="clr-namespace:FlowHub.Models;assembly=FlowHub.Models"
              x:DataType="viewModels:HomePageVM"
              >
     <VerticalStackLayout>
@@ -21,35 +22,53 @@
             <Border.Shadow>
                 <Shadow Offset="15,20" Opacity="0.1"/>
             </Border.Shadow>
-            <VerticalStackLayout Spacing="10" Margin="6">
-                <Label Text="Latest Flow Out"
-                            FontSize="25"
-                            HorizontalOptions="Center"
-                            Margin="90,0,0,0"
-                            WidthRequest="320"/>
-                <Rectangle
-                        Fill="DarkSlateBlue"
-                        HeightRequest="2"/>
-                <HorizontalStackLayout>
-                    <Label Text="{Binding ExpendituresDetails.Reason, StringFormat='Reason : {0}'}" FontSize="16"/>
-                    
-                </HorizontalStackLayout>
-                <HorizontalStackLayout>
-                    <Label FontSize="16">
-                        <Label.Text>
-                            <MultiBinding StringFormat="{}Amount Spent : {0:n2} {1}">
-                                <Binding Path="ExpendituresDetails.AmountSpent"/>
-                                <Binding Path="UserCurrency"/>
-                            </MultiBinding>
-                        </Label.Text>
-                    </Label>
-                </HorizontalStackLayout>
-                <HorizontalStackLayout Margin="0,0,0,15">
-                    <Label Text="{Binding ExpendituresDetails.DateSpent, StringFormat='Date Spent {0:dd MMMM, yyyy}'}" 
-                           FontSize="16"/>
-                </HorizontalStackLayout>
-            </VerticalStackLayout>
+            <VerticalStackLayout Spacing="5">
+                <Label Text="Latest Flow Outs" FontSize="22" HorizontalOptions="Center" Padding="10,0,0,0"/>
+                <BoxView
+                        Color="DarkSlateBlue"
+                        HeightRequest="2"
+                        HorizontalOptions="Fill"/>
+                <CollectionView x:Name="ColView" ItemsSource="{Binding LatestExpenditures}" HorizontalOptions="FillAndExpand">
+                    <CollectionView.EmptyView>
+                        <VerticalStackLayout VerticalOptions="Center">
+                            <Image Source="nothing_found.png" MaximumHeightRequest="50"/>
+                            <Label Text="No Flow Outs Available..." HorizontalOptions="Center" VerticalOptions="Center" />
+                        </VerticalStackLayout>
+                    </CollectionView.EmptyView>
+                    <CollectionView.ItemTemplate>
+                        <DataTemplate x:DataType="models:ExpendituresModel">
+                            <Grid Margin="10,5">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*" />
+                                    <ColumnDefinition Width="Auto" />
+                                </Grid.ColumnDefinitions>
 
+                                <StackLayout Grid.Column="0">
+                                    <Label Text="{Binding Reason}" FontAttributes="Bold"/>
+                                    <Label Text="{Binding Category}" FontSize="10" FontAttributes="Italic"/>
+                                </StackLayout>
+
+                                <StackLayout Grid.Column="1" HorizontalOptions="End">
+                                    <Label FontAttributes="Bold">
+                                        <Label.Text>
+                                            <MultiBinding StringFormat="{}{0:n2} {1}">
+                                                <Binding Path="AmountSpent"/>
+                                                <Binding Path="Currency"/>
+                                            </MultiBinding>
+                                        </Label.Text>
+                                    </Label>
+                                    <Label Text="{Binding DateSpent, StringFormat='{0:MM/dd/yyyy}'}" FontSize="10"
+                                   HorizontalTextAlignment="End" FontAttributes="Italic"
+                                   />
+                                </StackLayout>
+                            </Grid>
+
+                        </DataTemplate>
+                    </CollectionView.ItemTemplate>
+                </CollectionView>
+
+            </VerticalStackLayout>
+            
         </Border>
         <VerticalStackLayout HorizontalOptions="Center">
             <ImageButton Source="{AppThemeBinding Dark=add_btn_d.png, Light=add_btn_l.png}"

--- a/FlowHub.Main/Views/Mobile/Statistics/StatisticsPageM.xaml
+++ b/FlowHub.Main/Views/Mobile/Statistics/StatisticsPageM.xaml
@@ -2,39 +2,198 @@
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="FlowHub.Main.Views.Mobile.Statistics.StatisticsPageM"
-             xmlns:viewModel="clr-namespace:FlowHub.Main.ViewModels.Statistics"
+             xmlns:material="clr-namespace:UraniumUI.Material.Controls;assembly=UraniumUI.Material"  
              xmlns:lvc="clr-namespace:LiveChartsCore.SkiaSharpView.Maui;assembly=LiveChartsCore.SkiaSharpView.Maui"
+             xmlns:models="clr-namespace:FlowHub.Models;assembly=FlowHub.Models"
+             xmlns:toolkit="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
+             xmlns:viewModel="clr-namespace:FlowHub.Main.ViewModels.Statistics"
              x:DataType="viewModel:StatisticsPageVM"
              x:Name="page"
-             Title="Statistics Page">
-    <VerticalStackLayout >
-        <Label 
-            Text="GRAPHS AND CHARTS!"
-            VerticalOptions="Center" 
-            HorizontalOptions="Center" />
+             Title="Flows Insight">
+    
+        <toolkit:DockLayout Margin="5,0">
+            <Label toolkit:DockLayout.DockPosition="Top"   IsVisible="false"                
+                FontSize="21"
+                Text="Graphs and Charts!"
+                VerticalOptions="Center"                    
+                HorizontalOptions="Center" />
+        
 
-        <lvc:PieChart x:Name="pieChart" HeightRequest="350" IsVisible="true"
-                      TooltipTextSize="35"
-                      ChartPointPointerDown="BarChart_ChartPointPointerDown"
-                      />
+        <HorizontalStackLayout IsVisible="false" Spacing="15" toolkit:DockLayout.DockPosition="Top"
+                              VerticalOptions="Center"                    
+                            HorizontalOptions="Center" >
+                <material:PickerField ItemsSource="{Binding MonthNames}" SelectedItem="{Binding SelectedMonthName}" BorderColor="DarkSlateGray"
+                                  SelectedValueChangedCommand="{Binding PopulateDataGridWithSelectedMonthDataCommand}"
+                                  Title="Month"/>
+                <material:PickerField ItemsSource="{Binding YearNames}" SelectedItem="{Binding SelectedYearValue}" BorderColor="DarkSlateGray" x:Name="YearPicker"
+                                  SelectedValueChangedCommand="{Binding PopulateDataGridWithSelectedMonthDataCommand}"
+                                  Title="Year"/>
+            </HorizontalStackLayout>
+            <ScrollView
+                Orientation="Horizontal"
+                HorizontalOptions="FillAndExpand"
+                HorizontalScrollBarVisibility="Always"
+                toolkit:DockLayout.DockPosition="Top">
+                <HorizontalStackLayout Spacing="5" toolkit:DockLayout.DockPosition="Top" HorizontalOptions="CenterAndExpand">
+                    <HorizontalStackLayout.Resources>
+                        <ResourceDictionary>
+                            <Style TargetType="Border">
+                                <Setter Property="WidthRequest" Value="180"/>
+                                <Setter Property="HeightRequest" Value="55"/>
+                                <Setter Property="Padding" Value="0,3"/>
+                                <Setter Property="Margin" Value="0,10"/>
+                                <Setter Property="Stroke" Value="DarkSlateGray"/>
+                            </Style>
+                            <Style TargetType="VerticalStackLayout">
+                                <Setter Property="HorizontalOptions" Value="CenterAndExpand"/>
+                            </Style>
+                        </ResourceDictionary>
+                    </HorizontalStackLayout.Resources>
+                    <Border WidthRequest="195">
+                        <VerticalStackLayout>
+                            <Label Text="Total Number of Flows" FontSize="16" />
+                            <Label Text="{Binding TotalNumberOfExpenditures, StringFormat='{0} Flows'}" HorizontalTextAlignment="Center"/>
+                        </VerticalStackLayout>
+                    </Border>
+                    <Border>
+                        <VerticalStackLayout>
+                            <Label Text="Total Flows Amount" FontSize="16"/>
+                            <Label HorizontalTextAlignment="Center">
+                                <Label.Text>
+                                    <MultiBinding StringFormat="{}{0:n2} {1}">
+                                        <Binding Path="TotalMonthlyAmount"/>
+                                        <Binding Path="Currency"/>
+                                    </MultiBinding>
+                                </Label.Text>
+                            </Label>
+                        </VerticalStackLayout>
+                    </Border>
+                    <Border>
+                        <VerticalStackLayout>
+                            <Label Text="Average Daily Flow" FontSize="16"/>
+                            <Label HorizontalTextAlignment="Center">
+                                <Label.Text>
+                                    <MultiBinding StringFormat="{}{0:n2} {1}">
+                                        <Binding Path="AverageDailyAmountInAMonth"/>
+                                        <Binding Path="Currency"/>
+                                    </MultiBinding>
+                                </Label.Text>
+                            </Label>
+                        </VerticalStackLayout>
+                    </Border>
+                    <Border>
+                        <VerticalStackLayout>
+                            <Label Text="Highest Flow Cost" FontSize="16" 
+                                   HorizontalTextAlignment="Center"/>
+                            <Label HorizontalTextAlignment="Center" FontSize="13">
+                                <Label.Text>
+                                    <MultiBinding StringFormat="{}{0:n2} {1}">
+                                        <Binding Path="BiggestAmountInAMonth"/>
+                                        <Binding Path="Currency"/>
+                                    </MultiBinding>
+                                </Label.Text>
+                            </Label>
+                        </VerticalStackLayout>
+                    </Border>
+                    <Border>
+                        <VerticalStackLayout>
+                            <Label Text="Lowest Flow Cost" FontSize="16"/>
+                            <Label HorizontalTextAlignment="Center">
+                                <Label.Text>
+                                    <MultiBinding StringFormat="{}{0:n2} {1}">
+                                        <Binding Path="SmallestAmountInAMonth"/>
+                                        <Binding Path="Currency"/>
+                                    </MultiBinding>
+                                </Label.Text>
+                            </Label>
+                        </VerticalStackLayout>
+                    </Border>
+                </HorizontalStackLayout>
 
-        <Rectangle HeightRequest="2" Fill="Darkslateblue"/>
+            </ScrollView>
 
-        <lvc:CartesianChart ChartPointPointerDown="BarChart_ChartPointPointerDown" IsVisible="false"
-            x:Name="BarChart" HeightRequest="250"              
-                            ZoomMode="Both"
-            TooltipTextSize="35" 
-            LegendPosition="Bottom"
-            LegendTextPaint="{Binding LegendTextPaint}"
-            LegendTextSize="35">    
+            <ScrollView 
+                        HeightRequest="300"
+                Orientation="Horizontal"
+                HorizontalOptions="FillAndExpand"
+                toolkit:DockLayout.DockPosition="Top">
 
-        </lvc:CartesianChart>
+                <HorizontalStackLayout toolkit:DockLayout.DockPosition="Top" HorizontalOptions="Center" Spacing="5" Margin="10">
+                    <Border StrokeThickness="0">
 
-        <lvc:CartesianChart  HeightRequest="200" x:Name="OtherBar"
-            Series="{Binding Series2}"
-            YAxes="{Binding YAxes}"
-            ZoomMode="Both"/>
+                        <lvc:CartesianChart HeightRequest="300" WidthRequest="300"
+                            Series="{Binding MySeries}"
+                            XAxes="{Binding XAxes}"
+                            x:Name="DateTimeExpGraph"
+                            TooltipTextSize="37"
+                            LegendTextSize="37"                                            
+                            ChartPointPointerDownCommand="{Binding BarChartPointHoverCommand}">
+                            
+                        </lvc:CartesianChart>
+                    </Border>
+                    
+                    <Border StrokeThickness="0">
+                        <lvc:PieChart HeightRequest="300" WidthRequest="350" x:Name="myPieChart"
+                              Title="{Binding MyPieCategoriesTitle}"
+                              Series="{Binding MyPieSeries}"
+                              LegendTextSize="37"
+                              TooltipTextSize="47"
+                              LegendPosition="Right"
+                              ChartPointPointerDownCommand="{Binding PieChartClickCommand}"/>
+                    </Border>
 
-        <Button Text="November" Command="{Binding GetNovCommand}"/>
-    </VerticalStackLayout>
+                </HorizontalStackLayout>
+            </ScrollView>
+
+        <Label toolkit:DockLayout.DockPosition="Top"
+                VerticalOptions="Center" FontSize="21"             
+                HorizontalOptions="Center"
+                TextDecorations="Underline">
+            <Label.Text>
+                <MultiBinding StringFormat="{}{0} {1}">
+                    <Binding Path="SelectedMonthName"/>
+                    <Binding Path="SelectedYearValue"/>
+                </MultiBinding>
+            </Label.Text>
+        </Label>
+        <CollectionView x:Name="ColView" ItemsSource="{Binding ExpendituresForSelectedMonth}" HorizontalOptions="FillAndExpand">
+            <CollectionView.EmptyView>
+                <Label Text="No Flow Outs Available..." HorizontalOptions="Center" VerticalOptions="Center" />
+            </CollectionView.EmptyView>
+            <CollectionView.ItemTemplate>
+                <DataTemplate x:DataType="models:ExpendituresModel">
+                    <Grid Margin="10,5">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
+
+                        <StackLayout Grid.Column="0">
+                            <Label Text="{Binding Reason}" FontAttributes="Bold"/>
+                            <Label Text="{Binding Category}" FontSize="10" FontAttributes="Italic"/>
+                        </StackLayout>
+
+                        <StackLayout Grid.Column="1" HorizontalOptions="End">
+                            <Label FontAttributes="Bold">
+                                <Label.Text>
+                                    <MultiBinding StringFormat="{}{0:n2} {1}">
+                                        <Binding Path="AmountSpent"/>
+                                        <Binding Path="Currency"/>
+                                    </MultiBinding>
+                                </Label.Text>
+                            </Label>
+                            <Label Text="{Binding DateSpent, StringFormat='{0:MM/dd/yyyy}'}" FontSize="10"
+                                   HorizontalTextAlignment="End" FontAttributes="Italic"
+                                   />
+                        </StackLayout>
+                    </Grid>
+                    
+                </DataTemplate>
+            </CollectionView.ItemTemplate>
+        </CollectionView>
+
+
+
+    </toolkit:DockLayout>
+    
 </ContentPage>

--- a/FlowHub.Models/ExpendituresModel.cs
+++ b/FlowHub.Models/ExpendituresModel.cs
@@ -23,7 +23,6 @@ public class ExpendituresModel
     public string? PlatformModel { get; set; }
     public bool UpdateOnSync { get; set; } = false;
     public string UserId { get; set; }
-
 }
 
 public enum ExpenditureCategory


### PR DESCRIPTION
- Added statistics page with Graphs and Charts on Desktop and Mobile where users can have an insight of their data. This fixes #35 
- Added a little History of latest flows on HomePage on both Platforms. Closes #41  QoL improvemnts:
- largely improved the speed/performance when going to the ManageExpenditures pages on both Platforms
- Pratically removed the lag that exists when navigating from StatisticsPageM to ManageExpendituresM. Added a bool that will ensure that the Observable collections are not initialized on every navigation
- Added an event that will be listened and will be used to notify when OfflineExpendituresList is updated
- Probably other stuff that I forgot to mention